### PR TITLE
Temporarily compensate for corrupted base64 strings in excludeCredentials

### DIFF
--- a/Src/DSInternals.Win32.WebAuthn.Tests/PublicKeyCredentialCreationOptionsTester.cs
+++ b/Src/DSInternals.Win32.WebAuthn.Tests/PublicKeyCredentialCreationOptionsTester.cs
@@ -55,6 +55,21 @@ namespace DSInternals.Win32.WebAuthn.Tests
                         ""type"": ""public-key"",
                         ""id"": ""9ccVagkzE02vPo+qoonYDv8FoREd9QYOn8RFSsbLr8Y="",
                         ""transports"":[]
+                    },
+                    {
+                        ""type"": ""public-key"",
+                        ""id"": ""prXptqCfm_ohEAcE2Jw6CUtUb4uWpb2vaS-cFB82ruMhcIRAE17S0g1bkPjtsC6S0"",
+                        ""transports"":[]
+                    },
+                    {
+                        ""type"": ""public-key"",
+                        ""id"": ""MMeD8wrNCZ-0hbfdYvvAIzrsrTGd_uXdt2iXbYlGJSs1"",
+                        ""transports"":[]
+                    },
+                    {
+                        ""type"": ""public-key"",
+                        ""id"": ""owBYhYk51YPpOdLDJ-mcaIFdZVcCZ63YFogBU0VyJ42UkiptLxN5l7ZkRu4KtEo4XFJfJcahJ5C5uTj4YKxTmeISUiuOSgtBHlUh_RndhweyQJ8UY3HWwqvN57T3cvqXy_nG2VsR-Gw2upzNUW4LHGFjfSXj3rEe3B6KltliX1c68aDqDh3dquwBTAK9roaQzq3XZBZT_AJQKX2qop1j1Fh2-xOdeFR7aQ2"",
+                        ""transports"":[]
                     }
                 ],
                 ""authenticatorSelection"": {

--- a/Src/DSInternals.Win32.WebAuthn/Serialization/Base64UrlConverter.cs
+++ b/Src/DSInternals.Win32.WebAuthn/Serialization/Base64UrlConverter.cs
@@ -75,6 +75,27 @@ namespace DSInternals.Win32.WebAuthn
                 throw new ArgumentNullException(nameof(input));
             }
 
+            // START temporary workaround for MSFT bug (https://github.com/MichaelGrafnetter/webauthn-interop/issues/21)
+            // Checking to see if the last character is a digit and if we removed it, would there be anything left
+            if (input.Length > 1 && char.IsDigit((char)input[input.Length - 1]))
+            {
+                // Looking for last character to be 0, 1, or 2
+                char lastChar = (char)input[input.Length - 1];
+
+                // If we removed the last character, calculate the padding required for the remaining string
+                int potentialPaddingLength = (input.Length - 1) % 4;
+
+                // If the last character matches the padding length of the remaining string, this is very likely the case we are looking for
+                if ((lastChar == '0' && potentialPaddingLength == 0) ||
+                    (lastChar == '1' && potentialPaddingLength == 3) ||
+                    (lastChar == '2' && potentialPaddingLength == 2))
+                {
+                    // Update the input to remove the last character
+                    input = input.Slice(0, input.Length - 1);
+                }
+            }
+            // END temporary workaround
+                
             int paddingLength = (input.Length % 4) switch
             {
                 0 => 0, // Padding is not needed


### PR DESCRIPTION
- Implement **temporary** workaround for corrupted base64 string in excludeCredentials (see #21)
- Add real world sample corrupted credential ids to deserialization test

This is obviously not ideal as there may be a very, very small chance of a false positive (somehow, maybe?) but I think it will be an acceptable temporary workaround.