### PR TITLE
Support Windows 11 24H2+ passkey provider routing

### DIFF
--- a/Src/DSInternals.Win32.WebAuthn/WebAuthnApi.cs
+++ b/Src/DSInternals.Win32.WebAuthn/WebAuthnApi.cs
@@ -456,6 +456,36 @@ namespace DSInternals.Win32.WebAuthn
                 windowHandle = WindowHandle.ForegroundWindow;
             }
 
+            // Windows 11 24H2+ system passkey providers (e.g. 1Password) receive the original
+            // PublicKeyCredentialCreationOptions JSON from webauthn.dll. When the caller hasn't
+            // supplied one, synthesize it from the individual parameters so plug-in authenticators
+            // are still routed and appear in the OS picker.
+            if (publicKeyCredentialCreationOptionsJson is null or { Length: 0 })
+            {
+                publicKeyCredentialCreationOptionsJson = Encoding.UTF8.GetBytes(
+                    new PublicKeyCredentialCreationOptions
+                    {
+                        RelyingParty = rpEntity,
+                        User = userEntity,
+                        Challenge = clientData.Challenge,
+                        PublicKeyCredentialParameters = pubKeyCredParams
+                            .Select(alg => new PublicKeyCredentialParameter(alg, ApiConstants.PublicKeyCredentialType))
+                            .ToArray(),
+                        TimeoutMilliseconds = timeoutMilliseconds,
+                        ExcludeCredentials = excludeCredentials,
+                        AuthenticatorSelection = new AuthenticatorSelectionCriteria
+                        {
+                            AuthenticatorAttachment = authenticatorAttachment,
+                            UserVerificationRequirement = userVerificationRequirement,
+                            ResidentKey = residentKey,
+                            RequireResidentKey = residentKey == ResidentKeyRequirement.Required,
+                        },
+                        Attestation = attestationConveyancePreference,
+                        Extensions = extensions,
+                        Hints = credentialHints,
+                    }.ToString());
+            }
+
             using (var excludeCreds = new DisposableList<CredentialIn>())
             using (var excludeCredsEx = new DisposableList<CredentialEx>())
             {
@@ -810,6 +840,25 @@ namespace DSInternals.Win32.WebAuthn
             if (!windowHandle.IsValid)
             {
                 windowHandle = WindowHandle.ForegroundWindow;
+            }
+
+            // Windows 11 24H2+ system passkey providers (e.g. 1Password) receive the original
+            // PublicKeyCredentialRequestOptions JSON from webauthn.dll. When the caller hasn't
+            // supplied one, synthesize it from the individual parameters so plug-in authenticators
+            // are still routed and appear in the OS picker.
+            if (publicKeyCredentialRequestOptionsJson is null or { Length: 0 })
+            {
+                publicKeyCredentialRequestOptionsJson = Encoding.UTF8.GetBytes(
+                    new PublicKeyCredentialRequestOptions
+                    {
+                        Challenge = clientData.Challenge,
+                        Timeout = timeoutMilliseconds,
+                        RpId = rpId,
+                        AllowCredentials = allowCredentials,
+                        UserVerification = userVerificationRequirement,
+                        Hints = credentialHints,
+                        Extensions = extensions,
+                    }.ToString());
             }
 
             using (var allowCreds = new DisposableList<CredentialIn>())

--- a/Src/PasskeyUI/Views/MainWindow/MainWindowViewModel.cs
+++ b/Src/PasskeyUI/Views/MainWindow/MainWindowViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -240,6 +241,30 @@ internal sealed class MainWindowViewModel : BindableBase
             // Convert single hint to array if specified
             string[]? credentialHints = GetCredentialHints(AttestationOptionsViewModel.CredentialHint);
 
+            // Pass the original PublicKeyCredentialCreationOptions JSON so Windows can route
+            // the request to plug-in passkey providers (1Password, Bitwarden, etc.).
+            byte[] creationOptionsJson = Encoding.UTF8.GetBytes(
+                new PublicKeyCredentialCreationOptions
+                {
+                    RelyingParty = AttestationOptionsViewModel.RelyingPartyEntity,
+                    User = AttestationOptionsViewModel.UserEntity,
+                    Challenge = AttestationOptionsViewModel.Challenge!,
+                    PublicKeyCredentialParameters = (AttestationOptionsViewModel.PublicKeyCredentialParameters ?? [Algorithm.ES256])
+                        .Select(alg => new PublicKeyCredentialParameter(alg, ApiConstants.PublicKeyCredentialType))
+                        .ToArray(),
+                    TimeoutMilliseconds = AttestationOptionsViewModel.Timeout,
+                    AuthenticatorSelection = new AuthenticatorSelectionCriteria
+                    {
+                        AuthenticatorAttachment = AttestationOptionsViewModel.AuthenticatorAttachment,
+                        UserVerificationRequirement = AttestationOptionsViewModel.UserVerificationRequirement,
+                        ResidentKey = AttestationOptionsViewModel.ResidentKey,
+                        RequireResidentKey = AttestationOptionsViewModel.ResidentKey == ResidentKeyRequirement.Required,
+                    },
+                    Attestation = AttestationOptionsViewModel.AttestationConveyancePreference,
+                    Extensions = AttestationOptionsViewModel.ClientExtensions,
+                    Hints = credentialHints,
+                }.ToString());
+
             var response = await _api.AuthenticatorMakeCredentialAsync(
                 AttestationOptionsViewModel.RelyingPartyEntity,
                 AttestationOptionsViewModel.UserEntity,
@@ -256,6 +281,7 @@ internal sealed class MainWindowViewModel : BindableBase
                 browserInPrivateMode: AttestationOptionsViewModel.IsBrowserPrivateMode,
                 linkedDevice: null,
                 credentialHints: credentialHints,
+                publicKeyCredentialCreationOptionsJson: creationOptionsJson,
                 windowHandle: WindowHandle.MainWindow
                 );
 
@@ -277,6 +303,19 @@ internal sealed class MainWindowViewModel : BindableBase
             // Convert single hint to array if specified
             string[]? credentialHints = GetCredentialHints(AssertionOptionsViewModel.CredentialHint);
 
+            // Pass the original PublicKeyCredentialRequestOptions JSON so Windows can route
+            // the request to plug-in passkey providers (1Password, Bitwarden, etc.).
+            byte[] requestOptionsJson = Encoding.UTF8.GetBytes(
+                new PublicKeyCredentialRequestOptions
+                {
+                    Challenge = AssertionOptionsViewModel.Challenge!,
+                    Timeout = AssertionOptionsViewModel.Timeout,
+                    RpId = AssertionOptionsViewModel.RelyingPartyId,
+                    UserVerification = AssertionOptionsViewModel.UserVerificationRequirement,
+                    Hints = credentialHints,
+                    Extensions = AssertionOptionsViewModel.ClientExtensions,
+                }.ToString());
+
             var response = await _api.AuthenticatorGetAssertionAsync(
                 AssertionOptionsViewModel.RelyingPartyId,
                 AssertionOptionsViewModel.Challenge,
@@ -288,6 +327,7 @@ internal sealed class MainWindowViewModel : BindableBase
                 browserInPrivateMode: AssertionOptionsViewModel.IsBrowserPrivateMode,
                 linkedDevice: null,
                 credentialHints: credentialHints,
+                publicKeyCredentialRequestOptionsJson: requestOptionsJson,
                 windowHandle: WindowHandle.MainWindow
             );
 


### PR DESCRIPTION
## Summary
This PR adds support for routing WebAuthn requests to Windows 11 24H2+ system passkey providers (such as 1Password and Bitwarden) by synthesizing and passing the original `PublicKeyCredentialCreationOptions` and `PublicKeyCredentialRequestOptions` JSON to the WebAuthn API.

## Key Changes

- **WebAuthnApi.cs**: Added logic to synthesize `PublicKeyCredentialCreationOptions` JSON in `AuthenticatorMakeCredential()` when not supplied by the caller, ensuring plug-in authenticators are properly routed and appear in the OS picker on Windows 11 24H2+

- **WebAuthnApi.cs**: Added similar logic to synthesize `PublicKeyCredentialRequestOptions` JSON in `AuthenticatorGetAssertion()` when not supplied by the caller

- **MainWindowViewModel.cs**: Updated `OnRegister()` to construct and pass the complete `PublicKeyCredentialCreationOptions` JSON to the WebAuthn API call

- **MainWindowViewModel.cs**: Updated `OnAuthenticate()` to construct and pass the complete `PublicKeyCredentialRequestOptions` JSON to the WebAuthn API call

## Implementation Details

- The synthesized JSON objects are constructed from individual parameters that were already being passed separately
- This change is backward compatible—the fallback synthesis in `WebAuthnApi.cs` ensures the feature works even if callers don't provide the JSON
- The implementation follows the Windows 11 24H2+ requirement where system passkey providers receive the original credential options JSON from webauthn.dll for proper routing and display in the OS picker

https://claude.ai/code/session_01RGRw9BYAWZSZDU5jKTPu5x